### PR TITLE
Remove deprecated `@ember/error` refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --no-lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## ember-fsm-bridge
 
+### 2.0.0-alpha.1
+
+- Replace `@ember/error` with standard browser `Error` due to
+  [deprecation](https://deprecations.emberjs.com/v4.x#toc_deprecate-ember-error)
+  in Ember 4.x.
+
 ### 2.0.0-alpha.0
 
 - [BREAKING] Package forked as `ember-fsm-bridge`.

--- a/addon/-machine.js
+++ b/addon/-machine.js
@@ -1,4 +1,3 @@
-import EmberError from '@ember/error';
 import { A } from '@ember/array';
 import EmberObject, { computed } from '@ember/object';
 import { typeOf } from '@ember/utils';
@@ -49,7 +48,7 @@ export default EmberObject.extend({
     let sameState;
 
     if (!contains(this.eventNames, event)) {
-      throw new EmberError(
+      throw new Error(
         `unknown state event "${event}" try one of [` +
         this.eventNames.join(', ') + ']'
       );
@@ -59,7 +58,7 @@ export default EmberObject.extend({
     sameState  = transition.toState === this.currentState;
 
     if (this.isTransitioning && !sameState) {
-      throw new EmberError(
+      throw new Error(
         `unable to transition out of "${this.currentState}" ` +
         `state to "${transition.toState}" state while transitions are ` +
         `active: ${inspect(this.activeTransitions)}`
@@ -182,14 +181,14 @@ export default EmberObject.extend({
     let transitionParams;
 
     if (!potentials.length) {
-      throw new EmberError(`no transition is defined for event "${event}" ` +
+      throw new Error(`no transition is defined for event "${event}" ` +
       `in state "${currentState}"`);
     }
 
     transitionParams = this.outcomeOfPotentialTransitions(potentials);
 
     if (!transitionParams) {
-      throw new EmberError('no unguarded transition was resolved for event ' +
+      throw new Error('no unguarded transition was resolved for event ' +
       `"${event}" in state "${currentState}"`);
     }
 

--- a/addon/-reject.js
+++ b/addon/-reject.js
@@ -1,5 +1,3 @@
-import EmberError from '@ember/error';
-
 export function reject() {
-  throw new EmberError('rejected transition');
+  throw new Error('rejected transition');
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-fsm-bridge",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "description": "An Octane-compatible fork of ember-fsm",
   "homepage": "https://github.com/gorner/ember-fsm-bridge",
   "bugs": {


### PR DESCRIPTION
Required for Ember 5 support.